### PR TITLE
parse insert with functions

### DIFF
--- a/lib/SQL/Parser.pm
+++ b/lib/SQL/Parser.pm
@@ -20,7 +20,7 @@ use constant BAREWORD_FUNCTIONS =>
 use Carp qw(carp croak);
 use Params::Util qw(_ARRAY0 _ARRAY _HASH);
 use Scalar::Util qw(looks_like_number);
-
+use Text::Balanced qw(extract_bracketed);
 $VERSION = '1.406';
 
 BEGIN
@@ -711,10 +711,10 @@ sub INSERT
     my ( $self, $str ) = @_;
     my $col_str;
     $str =~ s/^INSERT\s+INTO\s+/INSERT /i;    # allow INTO to be optional
-    my ( $table_name, $val_str ) = $str =~ m/^INSERT\s+(.+?)\s+VALUES\s+(\(.+?\))$/i;
+    my ( $table_name, $val_str ) = $str =~ m/^INSERT\s+(.+?)\s+VALUES\s+(\(.+\))$/i;
     if ( $table_name and $table_name =~ m/[()]/ )
     {
-        ( $table_name, $col_str, $val_str ) = $str =~ m/^INSERT\s+(.+?)\s+\((.+?)\)\s+VALUES\s+(\(.+?\))$/i;
+        ( $table_name, $col_str, $val_str ) = $str =~ m/^INSERT\s+(.+?)\s+\((.+?)\)\s+VALUES\s+(\(.+\))$/i;
     }
     return $self->do_err('No table name specified!') unless ($table_name);
     return $self->do_err('Missing values list!')     unless ( defined $val_str );
@@ -735,11 +735,13 @@ sub INSERT
         ];
     }
     $self->{struct}->{values} = [];
-    while ( $val_str =~ m/\((.+?)\)(?:,|$)/g )
-    {
-        my $line_str = $1;
-        return undef unless ( $self->LITERAL_LIST($line_str) );
+    for (my ($v,$line_str) = $val_str;
+	 (($line_str,$v)=extract_bracketed($v,"('",'')) && defined $line_str;
+	) {
+      return undef unless ( $self->LITERAL_LIST(substr($line_str,1,-1)) );
+      last unless $v =~ s/\A\s*,\s*//;
     }
+
     return 1;
 }
 

--- a/t/01prepare.t
+++ b/t/01prepare.t
@@ -46,6 +46,9 @@ UPDATE foo SET bar = 7 WHERE id > 7
   /* INSERT */
 INSERT INTO foo VALUES ( 'baz', 7, NULL )
 INSERT INTO foo (col1,col2,col7) VALUES ( 'baz', 7, NULL )
+INSERT INTO foo VALUES ( now(), trim(lower(user)), curdate-1 )
+INSERT INTO foo VALUES ( 'smile :-),(-: twice)', ' \\' ) ' )
+INSERT INTO foo VALUES (1,'row'),(2,'rows')
   /* CREATE TABLE */
 CREATE TABLE foo ( id INT )
 CREATE LOCAL TEMPORARY TABLE foo (id INT)


### PR DESCRIPTION
Allows functions with parenthesis to appear in an INSERT VALUES list.
Also added tests for that case. This patch adds a dependency on
Text::Balanced, which is pure Perl and works with older Perl versions. I
considered Regexp::Common, but figuring out a regexp that worked with
old & new perl's both was more work than I cared for.

ps. The original code allowed multiple value lists, eg "insert into foo
values ('a',1),('b',2),('c',3)" so I kept that functional and also added
a test for that.