### PR TITLE
Use a defined owner

### DIFF
--- a/lib/SQL/Statement/Function.pm
+++ b/lib/SQL/Statement/Function.pm
@@ -223,7 +223,7 @@ sub value($)
       map { _INSTANCE( $_, 'SQL::Statement::Term' ) ? $_->value($eval) : $_ } @{ $self->{PARAMS} };
     foreach my $val (@vals)
     {
-        return $owner->do_err(qq~Bad numeric expression '$val'!~)
+        return $self->{OWNER}->do_err(qq~Bad numeric expression '$val'!~)
           unless ( defined( _NUMBER($val) ) );
     }
     $expr =~ s/\?(\d+)\?/$vals[$1]/g;


### PR DESCRIPTION
Commit af13adb1f489f88a4 is breaking the tests. I've switched

        $owner->

for

        $self->{OWNER}->

and now things are passing. 

BIG WARNING: I'm not sure of the fix
af13adb1f489f88a4 was trying to do in the first place, so my
own patch could be flawed.