### PR TITLE
Remove links to annocpan & cpanratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,6 @@ You can also look for information at:
 
     [http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement](http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement)
 
-- AnnoCPAN: Annotated CPAN documentation
-
-    [http://annocpan.org/dist/SQL-Statement](http://annocpan.org/dist/SQL-Statement)
-
-- CPAN Ratings
-
-    [http://cpanratings.perl.org/s/SQL-Statement](http://cpanratings.perl.org/s/SQL-Statement)
-
 - CPAN Search
 
     [http://search.cpan.org/dist/SQL-Statement/](http://search.cpan.org/dist/SQL-Statement/)

--- a/lib/SQL/Eval.pm
+++ b/lib/SQL/Eval.pm
@@ -538,14 +538,6 @@ You can also look for information at:
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/SQL-Statement>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/s/SQL-Statement>
-
 =item * Search CPAN
 
 L<http://search.cpan.org/dist/SQL-Statement/>

--- a/lib/SQL/Parser.pm
+++ b/lib/SQL/Parser.pm
@@ -3388,14 +3388,6 @@ You can also look for information at:
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/SQL-Statement>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/s/SQL-Statement>
-
 =item * Search CPAN
 
 L<http://search.cpan.org/dist/SQL-Statement/>

--- a/lib/SQL/Statement.pm
+++ b/lib/SQL/Statement.pm
@@ -2598,14 +2598,6 @@ You can also look for information at:
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/SQL-Statement>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/s/SQL-Statement>
-
 =item * CPAN Search
 
 L<http://search.cpan.org/dist/SQL-Statement/>

--- a/lib/SQL/Statement/RAM.pm
+++ b/lib/SQL/Statement/RAM.pm
@@ -275,14 +275,6 @@ You can also look for information at:
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=SQL-Statement>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/SQL-Statement>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/s/SQL-Statement>
-
 =item * Search CPAN
 
 L<http://search.cpan.org/dist/SQL-Statement/>


### PR DESCRIPTION
 - annocpan has lapsed and hosts some kind of link farm
 - cpanratings is read-only and has no ratings for this module